### PR TITLE
fix: make task ID generation atomic to prevent duplicates under concurrency

### DIFF
--- a/cmd/coverage_test.go
+++ b/cmd/coverage_test.go
@@ -965,13 +965,17 @@ func TestResolveDir_WithFlagDir(t *testing.T) {
 	oldFlagDir := flagDir
 	flagDir = "/some/path"
 	t.Cleanup(func() { flagDir = oldFlagDir })
-
 	got, err := resolveDir()
 	if err != nil {
 		t.Fatalf("resolveDir() error: %v", err)
 	}
-	if got != "/some/path" {
-		t.Errorf("resolveDir() = %q, want %q", got, "/some/path")
+	// The result should be an absolute path (platform-normalized)
+	wantAbs, err := filepath.Abs("/some/path")
+	if err != nil {
+		t.Fatalf("filepath.Abs() error: %v", err)
+	}
+	if got != wantAbs {
+		t.Errorf("resolveDir() = %q, want %q", got, wantAbs)
 	}
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -101,7 +102,12 @@ func Execute() {
 // resolveDir returns the absolute path to the kanban directory.
 func resolveDir() (string, error) {
 	if flagDir != "" {
-		return flagDir, nil
+		// Normalize the path to absolute form to ensure consistent lock file paths.
+		abs, err := filepath.Abs(flagDir)
+		if err != nil {
+			return "", fmt.Errorf("resolving absolute path for %q: %w", flagDir, err)
+		}
+		return abs, nil
 	}
 
 	cwd, err := os.Getwd()

--- a/internal/tui/create_test.go
+++ b/internal/tui/create_test.go
@@ -220,21 +220,22 @@ func TestCreate_UsesCurrentColumnStatus(t *testing.T) {
 
 func TestCreate_NextIDIncrements(t *testing.T) {
 	b, cfg := setupTestBoard(t)
-
-	initialNextID := cfg.NextID
-
+	// setupTestBoard creates 4 tasks (IDs 1-4), so the actual max ID is 4.
+	// When executeCreate runs, defense-in-depth will scan files and set NextID=5,
+	// then create task 5 and increment to 6.
+	const maxExistingID = 4
+	expectedNextID := maxExistingID + 2 // +1 for the created task, +1 for next
 	// Create a task using Enter to finish immediately from title.
 	b = sendKey(b, "c")
 	b = typeText(b, "Increment test")
 	_ = sendSpecialKey(b, tea.KeyEnter)
-
-	// Reload config and check NextID incremented.
+	// Reload config and check NextID incremented correctly.
 	reloaded, err := config.Load(cfg.Dir())
 	if err != nil {
 		t.Fatal(err)
 	}
-	if reloaded.NextID != initialNextID+1 {
-		t.Errorf("NextID = %d, want %d", reloaded.NextID, initialNextID+1)
+	if reloaded.NextID != expectedNextID {
+		t.Errorf("NextID = %d, want %d", reloaded.NextID, expectedNextID)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes #2

- **Root cause**: TUI `executeCreate()` bypassed the file lock and used a stale in-memory `NextID`, causing duplicate IDs when multiple agents created tasks concurrently. No defense existed against stale `NextID` values from crashes, manual edits, or worktree operations.
- **Fix**: Add `MaxIDFromFiles()` defense-in-depth that scans actual task files, fix TUI to acquire file lock and reload config, normalize paths for consistent lock files.
- **Tests**: Add e2e tests for stale NextID recovery and concurrent creates with pre-existing ID gaps.

## Changes

| File | What changed |
|------|-------------|
| `internal/task/find.go` | Add `MaxIDFromFiles()` — scans task files for true max ID |
| `cmd/create.go` | Add defense-in-depth: `nextID = max(cfg.NextID, maxFromFiles+1)` |
| `internal/tui/board.go` | Fix `executeCreate()`: acquire file lock, reload config, validate with `MaxIDFromFiles()` |
| `cmd/root.go` | Normalize `resolveDir()` with `filepath.Abs()` for consistent lock paths |
| `cmd/coverage_test.go` | Fix `TestResolveDir_WithFlagDir` for cross-platform (Windows) compatibility |
| `internal/tui/create_test.go` | Update `TestCreate_NextIDIncrements` for defense-in-depth behavior |
| `e2e/lifecycle_test.go` | Add `TestStaleNextIDRecovery` and `TestConcurrentCreateWithExistingGaps` |

## Testing

- `go test ./...` — all passing
- `TestStaleNextIDRecovery` — verifies recovery when NextID is stale (tasks exist with higher IDs)
- `TestConcurrentCreateWithExistingGaps` — 10 concurrent creates with pre-existing gapped task files, no duplicates
- `TestConcurrentCreateUniqueIDs` — existing test, still passing